### PR TITLE
Made locksmith look at cdk context

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-VERSION=0.0.3
+VERSION=0.1.0
 BUILD=$(shell git rev-parse --short HEAD)
 MODULE=locksmith
 BIN=bin
@@ -7,16 +7,11 @@ GOPATH=$(CURDIR)
 GOBIN=$(GOPATH)/$(BIN)
 
 _TARGETS=\
-	darwin-amd64
+	darwin-amd64 \
 	linux-amd64 \
 	linux-arm \
 	linux-arm64 \
 	windows-amd64
-
-	# android-386 \
-	# android-amd64 \
-	# android-arm \
-	# android-arm64 \
 
 TARGET_BINS=$(patsubst %,$(BIN)/$(MODULE)-%,$(_TARGETS))
 TARGET_ZIPS=$(patsubst %,$(DIST)/$(MODULE)-%-$(VERSION).zip,$(_TARGETS))

--- a/Makefile
+++ b/Makefile
@@ -7,13 +7,10 @@ GOPATH=$(CURDIR)
 GOBIN=$(GOPATH)/$(BIN)
 
 _TARGETS=\
-	darwin-386 \
-	darwin-amd64 \
-	linux-386 \
+	darwin-amd64
 	linux-amd64 \
 	linux-arm \
 	linux-arm64 \
-	windows-386 \
 	windows-amd64
 
 	# android-386 \

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,12 @@
+module github.com/sentialabs/locksmith-go/locksmith
+
+go 1.16
+
+require (
+	github.com/aws/aws-sdk-go v1.38.70
+	github.com/captainsafia/go-user-shell v0.0.0-20170316230437-490e66f0e9cb
+	github.com/manifoldco/promptui v0.8.0
+	github.com/smartystreets/goconvey v1.6.4 // indirect
+	gopkg.in/ini.v1 v1.62.0
+	gopkg.in/mattes/go-expand-tilde.v1 v1.0.0-20150330173918-cb884138e64c
+)

--- a/locksmith/main.go
+++ b/locksmith/main.go
@@ -278,6 +278,10 @@ func main() {
 
 	// Get venv setting
 	venv := os.Getenv("LOCKSMITH_VENV")
+
+	if len(venv) == 0 {
+		venv = context.Context.VirtualEnv
+	}
 	var cmd = exec.Command(shell, "-l")
 
 	if len(venv) != 0 {


### PR DESCRIPTION
Loads `cdk.json` from the current working directory and looks for the following context parameters:
```json
"venv": ".venv",
"environments": [
  {
    "account": "1234",
    "name": "acceptance"
  },
  {
    "account": "5678",
    "name": "production"
  }
]
```
`venv` should be set to the virtual environment folder. This will cause locksmith to source the `bin/activate` script on initialising the locksmith session. This is limited to `bash`, so it will override the `LOCKSMITH_SHELL` variable.

`environments` should be a list of accounts and their names. The name is not used by locksmith, but is useful for personal reference or use within the project. Locksmith uses the account numbers to filter out non-related bookmarks.

This change also sets the prompt to make clear what environment is active. This is limited to `bash` since `zsh` overrides the passed environment variable.